### PR TITLE
Added More Functionality

### DIFF
--- a/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
+++ b/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EF040563-38FB-491B-AA34-30B1BC7AB0CC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NLog.Targets.Sentry.UnitTests</RootNamespace>
+    <AssemblyName>NLog.Targets.Sentry.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog">
+      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpRaven">
+      <HintPath>..\packages\SharpRaven.1.4.3\lib\net45\SharpRaven.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SentryTargetTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLog.Targets.Sentry\NLog.Targets.Sentry.csproj">
+      <Project>{c4da3206-227c-4c65-86bb-0b91cb01b50b}</Project>
+      <Name>NLog.Targets.Sentry</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NLog.Targets.Sentry.UnitTests/Properties/AssemblyInfo.cs
+++ b/NLog.Targets.Sentry.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NLog.Targets.Sentry.UnitTests")]
+[assembly: AssemblyDescription("Custom target for NLog enabling you to send logging messages to the Sentry logging service.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Bjarne Riis")]
+[assembly: AssemblyProduct("NLog.Targets.Sentry.UnitTests")]
+[assembly: AssemblyCopyright("Copyright © 2015 Bjarne Riis")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1c924fcc-b923-49a0-b6bd-c1cca48f36e7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
+++ b/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using Moq;
+using NLog.Config;
+using NUnit.Framework;
+using SharpRaven;
+using SharpRaven.Data;
+
+namespace NLog.Targets.Sentry.UnitTests
+{
+    [TestFixture]
+    class SentryTargetTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            LogManager.ThrowExceptions = true;
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            LogManager.ThrowExceptions = false;
+        }
+
+        [Test]
+        public void TestPublicConstructor()
+        {
+            Assert.DoesNotThrow(() => new SentryTarget());
+            Assert.Throws<NLogConfigurationException>(() =>
+            {
+                var sentryTarget = new SentryTarget();
+                var configuration = new LoggingConfiguration();
+                configuration.AddTarget("NLogSentry", sentryTarget);
+                configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Trace, sentryTarget));
+                LogManager.Configuration = configuration;
+            });
+        }
+
+        [Test]
+        public void TestBadDsn()
+        {
+            Assert.Throws<ArgumentException>(() => new SentryTarget(null) { Dsn = "http://localhost" });
+        }
+
+        [Test]
+        public void TestLoggingToSentry()
+        {
+            var sentryClient = new Mock<IRavenClient>();
+            ErrorLevel lErrorLevel = ErrorLevel.Debug;
+            IDictionary<string, string> lTags = null;
+            Exception lException = null;
+
+            sentryClient
+                .Setup(x => x.CaptureException(It.IsAny<Exception>(), It.IsAny<SentryMessage>(), It.IsAny<ErrorLevel>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
+                .Callback((Exception exception, SentryMessage msg, ErrorLevel lvl, IDictionary<string, string> d, object extra) =>
+                {
+                    lException = exception;
+                    lErrorLevel = lvl;
+                    lTags = d;
+                })
+                .Returns("Done");
+
+            // Setup NLog
+            var sentryTarget = new SentryTarget(sentryClient.Object)
+            {
+                Dsn = "http://25e27038b1df4930b93c96c170d95527:d87ac60bb07b4be8908845b23e914dae@test/4",
+            };
+            var configuration = new LoggingConfiguration();
+            configuration.AddTarget("NLogSentry", sentryTarget);
+            configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Trace, sentryTarget));
+            LogManager.Configuration = configuration;
+
+            try
+            {
+                throw new Exception("Oh No!");
+            }
+            catch (Exception e)
+            {
+                var logger = LogManager.GetCurrentClassLogger();
+                logger.ErrorException("Error Message", e);
+            }
+
+            Assert.IsTrue(lException.Message == "Oh No!");
+            Assert.IsTrue(lTags == null);
+            Assert.IsTrue(lErrorLevel == ErrorLevel.Error);
+        }
+    }
+}

--- a/NLog.Targets.Sentry.UnitTests/packages.config
+++ b/NLog.Targets.Sentry.UnitTests/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
+  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="SharpRaven" version="1.4.3" targetFramework="net45" />
+</packages>

--- a/NLog.Targets.Sentry.sln
+++ b/NLog.Targets.Sentry.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.Sentry", "NLog.Targets.Sentry\NLog.Targets.Sentry.csproj", "{C4DA3206-227C-4C65-86BB-0B91CB01B50B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoApp", "DemoApp\DemoApp.csproj", "{B47DDADD-19D5-401D-8C10-9C93B67B3992}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.Sentry.UnitTests", "NLog.Targets.Sentry.UnitTests\NLog.Targets.Sentry.UnitTests.csproj", "{EF040563-38FB-491B-AA34-30B1BC7AB0CC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +15,10 @@ Global
 		{C4DA3206-227C-4C65-86BB-0B91CB01B50B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4DA3206-227C-4C65-86BB-0B91CB01B50B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4DA3206-227C-4C65-86BB-0B91CB01B50B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B47DDADD-19D5-401D-8C10-9C93B67B3992}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B47DDADD-19D5-401D-8C10-9C93B67B3992}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B47DDADD-19D5-401D-8C10-9C93B67B3992}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B47DDADD-19D5-401D-8C10-9C93B67B3992}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF040563-38FB-491B-AA34-30B1BC7AB0CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF040563-38FB-491B-AA34-30B1BC7AB0CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF040563-38FB-491B-AA34-30B1BC7AB0CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF040563-38FB-491B-AA34-30B1BC7AB0CC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
+++ b/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
@@ -41,11 +41,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/NLog.Targets.Sentry/Properties/AssemblyInfo.cs
+++ b/NLog.Targets.Sentry/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.1.0")]
 [assembly: AssemblyFileVersion("1.1.0")]
+[assembly: InternalsVisibleTo("NLog.Targets.Sentry.UnitTests")]

--- a/NLog.Targets.Sentry/SentryTarget.cs
+++ b/NLog.Targets.Sentry/SentryTarget.cs
@@ -40,9 +40,9 @@ namespace NLog.Targets
         }
 
         /// <summary>
-        /// Determins whether event messages will be captured as well as exceptions
+        /// Determines whether events with no exceptions will be send to Sentry or not
         /// </summary>
-        public bool CaptureMessages { get; set; }
+        public bool IgnoreEventsWithNoException { get; set; }
 
         /// <summary>
         /// Constructor
@@ -72,7 +72,9 @@ namespace NLog.Targets
                 var extras = logEvent.Properties.ToDictionary(x => x.Key.ToString(), x => x.Value.ToString());
                 client.Value.Logger = logEvent.LoggerName;
 
-                if (logEvent.Exception == null && CaptureMessages)
+                // If the log event did not contain an exception and we're not ignoring
+                // those kinds of events then we'll send a "Message" to Sentry
+                if (logEvent.Exception == null && !IgnoreEventsWithNoException)
                 {
                     var sentryMessage = new SentryMessage(Layout.Render(logEvent));
                     client.Value.CaptureMessage(sentryMessage, LoggingLevelMap[logEvent.Level], extra: extras);

--- a/NLog.Targets.Sentry/SentryTarget.cs
+++ b/NLog.Targets.Sentry/SentryTarget.cs
@@ -1,5 +1,10 @@
-﻿using NLog.Config;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLog.Common;
+using NLog.Config;
 using SharpRaven;
+using SharpRaven.Data;
 
 // ReSharper disable CheckNamespace
 namespace NLog.Targets
@@ -8,21 +13,84 @@ namespace NLog.Targets
     [Target("Sentry")]
     public class SentryTarget : TargetWithLayout
     {
-        [RequiredParameter]
-        public string Dsn { get; set; }
+        private Dsn _dsn;
+        private readonly Lazy<IRavenClient> _client;
 
+        /// <summary>
+        /// Map of NLog log levels to Raven/Sentry log levels
+        /// </summary>
+        protected static readonly IDictionary<LogLevel, ErrorLevel> LoggingLevelMap = new Dictionary<LogLevel, ErrorLevel>()
+        {
+            {LogLevel.Debug, ErrorLevel.Debug},
+            {LogLevel.Error, ErrorLevel.Error},
+            {LogLevel.Fatal, ErrorLevel.Fatal},
+            {LogLevel.Info, ErrorLevel.Info},
+            {LogLevel.Trace, ErrorLevel.Debug},
+            {LogLevel.Warn, ErrorLevel.Warning},
+        };
+
+        /// <summary>
+        /// The DSN for the Sentry host
+        /// </summary>
+        [RequiredParameter]
+        public string Dsn
+        {
+            get { return _dsn == null ? null : _dsn.ToString(); }
+            set { _dsn = new Dsn(value); }
+        }
+
+        /// <summary>
+        /// Determins whether event messages will be captured as well as exceptions
+        /// </summary>
+        public bool CaptureMessages { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public SentryTarget()
+        {
+            _client = new Lazy<IRavenClient>(() => new RavenClient(_dsn));
+        }
+
+        /// <summary>
+        /// Internal constructor, used for unit-testing
+        /// </summary>
+        /// <param name="ravenClient">A <see cref="IRavenClient"/></param>
+        internal SentryTarget(IRavenClient ravenClient) : this()
+        {
+            _client = new Lazy<IRavenClient>(() => ravenClient);
+        }
+
+        /// <summary>
+        /// Writes logging event to the log target.
+        /// </summary>
+        /// <param name="logEvent">Logging event to be written out.</param>
         protected override void Write(LogEventInfo logEvent)
         {
-            RavenClient sentryClient = new RavenClient(Dsn);
-            string message = Layout.Render(logEvent);
+            if (logEvent.Level == LogLevel.Off) return;
 
-            if (logEvent.Exception != null)
+            try
             {
-                sentryClient.CaptureException(logEvent.Exception, message);
+                var extras = logEvent.Properties.ToDictionary(x => x.Key.ToString(), x => x.Value.ToString());
+                _client.Value.Logger = logEvent.LoggerName;
+
+                if (logEvent.Exception == null && CaptureMessages)
+                {
+                    var message = Layout.Render(logEvent);
+                    if (string.IsNullOrEmpty(message)) return;
+
+                    var sentryMessage = new SentryMessage(message);
+                    _client.Value.CaptureMessage(sentryMessage, level: LoggingLevelMap[logEvent.Level], extra: extras);
+                }
+                else if (logEvent.Exception != null)
+                {
+                    var sentryMessage = new SentryMessage(logEvent.FormattedMessage);
+                    _client.Value.CaptureException(logEvent.Exception, extra: extras, level: LoggingLevelMap[logEvent.Level], message: sentryMessage);
+                }
             }
-            else
+            catch (Exception e)
             {
-                sentryClient.CaptureMessage(message);
+                InternalLogger.Error("Unable to send Sentry request: {0}", e.Message);
             }
         }
     }


### PR DESCRIPTION
- Exceptions can be captured with extra data in the LogEvent properties
- Levels are now translated from NLog to Sentry
- Internal logger used when failure
- Immediate error on bad DSN
- Added UnitTests

BREAKING:
- Message capture will only occur if CaptureMessages = true (Message
  capture sucks anyway)
