### PR TITLE
Update compatibility with latest Raven and NLog

### DIFF
--- a/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
+++ b/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
@@ -30,20 +30,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.3.4\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SharpRaven">
-      <HintPath>..\packages\SharpRaven.1.4.3\lib\net45\SharpRaven.dll</HintPath>
+    <Reference Include="SharpRaven, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpRaven.2.1.0\lib\net45\SharpRaven.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,13 +63,14 @@
     <Compile Include="SentryTargetTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\NLog.Targets.Sentry\NLog.Targets.Sentry.csproj">
       <Project>{c4da3206-227c-4c65-86bb-0b91cb01b50b}</Project>
       <Name>NLog.Targets.Sentry</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
+++ b/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
@@ -52,12 +52,12 @@ namespace NLog.Targets.Sentry.UnitTests
             Exception lException = null;
 
             sentryClient
-                .Setup(x => x.CaptureException(It.IsAny<Exception>(), It.IsAny<SentryMessage>(), It.IsAny<ErrorLevel>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
-                .Callback((Exception exception, SentryMessage msg, ErrorLevel lvl, IDictionary<string, string> d, object extra) =>
+                .Setup(x => x.Capture(It.IsAny<SentryEvent>()))
+                .Callback((SentryEvent sentryEvent) =>
                 {
-                    lException = exception;
-                    lErrorLevel = lvl;
-                    lTags = d;
+                    lException = sentryEvent.Exception;
+                    lErrorLevel = sentryEvent.Level;
+                    lTags = sentryEvent.Tags;
                 })
                 .Returns("Done");
 
@@ -78,12 +78,12 @@ namespace NLog.Targets.Sentry.UnitTests
             catch (Exception e)
             {
                 var logger = LogManager.GetCurrentClassLogger();
-                logger.ErrorException("Error Message", e);
+                logger.Error(e, "Error Message");
             }
 
-            Assert.IsTrue(lException.Message == "Oh No!");
-            Assert.IsTrue(lTags == null);
-            Assert.IsTrue(lErrorLevel == ErrorLevel.Error);
+            Assert.AreEqual(lException.Message, "Oh No!");
+            Assert.IsEmpty(lTags);
+            Assert.AreEqual(lErrorLevel, ErrorLevel.Error);
         }
 
 
@@ -98,12 +98,12 @@ namespace NLog.Targets.Sentry.UnitTests
             Exception lException = null;
 
             sentryClient
-                .Setup(x => x.CaptureException(It.IsAny<Exception>(), It.IsAny<SentryMessage>(), It.IsAny<ErrorLevel>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<object>()))
-                .Callback((Exception exception, SentryMessage msg, ErrorLevel lvl, IDictionary<string, string> d, object extra) =>
+                .Setup(x => x.Capture(It.IsAny<SentryEvent>()))
+                .Callback((SentryEvent sentryEvent) =>
                 {
-                    lException = exception;
-                    lErrorLevel = lvl;
-                    lTags = d;
+                    lException = sentryEvent.Exception;
+                    lErrorLevel = sentryEvent.Level;
+                    lTags = sentryEvent.Tags;
                 })
                 .Returns("Done");
 
@@ -128,14 +128,14 @@ namespace NLog.Targets.Sentry.UnitTests
             {
                 var logger = LogManager.GetCurrentClassLogger();
 
-                var logEventInfo = LogEventInfo.Create(LogLevel.Error, "default", "Error Message", e);
+                var logEventInfo = LogEventInfo.Create(LogLevel.Error, "default", e, message: "Error Message", formatProvider: null);
                 logEventInfo.Properties.Add("tag1", tag1Value);
                 logger.Log(logEventInfo);
             }
 
-            Assert.IsTrue(lException.Message == "Oh No!");
-            Assert.IsTrue(lTags != null);
-            Assert.IsTrue(lErrorLevel == ErrorLevel.Error);
+            Assert.AreEqual(lException.Message, "Oh No!");
+            Assert.AreEqual(lTags["tag1"], tag1Value);
+            Assert.AreEqual(lErrorLevel, ErrorLevel.Error);
         }
     }
 }

--- a/NLog.Targets.Sentry.UnitTests/app.config
+++ b/NLog.Targets.Sentry.UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/NLog.Targets.Sentry.UnitTests/packages.config
+++ b/NLog.Targets.Sentry.UnitTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
-  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SharpRaven" version="1.4.3" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="NLog" version="4.3.4" targetFramework="net45" />
+  <package id="NUnit" version="3.2.1" targetFramework="net45" />
+  <package id="SharpRaven" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
+++ b/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
@@ -30,14 +30,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.3.4\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SharpRaven">
-      <HintPath>..\packages\SharpRaven.1.4.3\lib\net45\SharpRaven.dll</HintPath>
+    <Reference Include="SharpRaven, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpRaven.2.1.0\lib\net45\SharpRaven.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,10 +50,11 @@
     <Compile Include="SentryTarget.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="NLog.Targets.Sentry.nuspec">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Packages.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/NLog.Targets.Sentry/Packages.config
+++ b/NLog.Targets.Sentry/Packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
-  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
-  <package id="SharpRaven" version="1.4.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="NLog" version="4.3.4" targetFramework="net45" />
+  <package id="SharpRaven" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/NLog.Targets.Sentry/SentryTarget.cs
+++ b/NLog.Targets.Sentry/SentryTarget.cs
@@ -84,23 +84,40 @@ namespace NLog.Targets
 
                 client.Value.Logger = logEvent.LoggerName;
 
+
                 // If the log event did not contain an exception and we're not ignoring
                 // those kinds of events then we'll send a "Message" to Sentry
-                if (logEvent.Exception == null && !IgnoreEventsWithNoException)
+                if ( (logEvent.Exception != null && !IgnoreEventsWithNoException) || (logEvent.Exception != null))
                 {
-                    var sentryMessage = new SentryMessage(Layout.Render(logEvent));
-                    client.Value.CaptureMessage(sentryMessage, LoggingLevelMap[logEvent.Level], extra: extras, tags: tags);
-                }
-                else if (logEvent.Exception != null)
-                {
-                    var sentryMessage = new SentryMessage(logEvent.FormattedMessage);
-                    client.Value.CaptureException(logEvent.Exception, extra: extras, level: LoggingLevelMap[logEvent.Level], message: sentryMessage, tags: tags);
+                    client.Value.Capture(LogEventToSentry(logEvent));
                 }
             }
             catch (Exception e)
             {
                 InternalLogger.Error("Unable to send Sentry request: {0}", e.Message);
             }
+        }
+
+        private SentryEvent LogEventToSentry(LogEventInfo logEvent)
+        {
+            var sentryEvent = logEvent.Exception == null
+                ? new SentryEvent(Layout.Render(logEvent))
+                : new SentryEvent(logEvent.Exception);
+
+            sentryEvent.Level = LoggingLevelMap[logEvent.Level];
+
+            if (SendLogEventInfoPropertiesAsTags)
+            {
+                var props = logEvent.Properties.ToDictionary(x => x.Key.ToString(), x => x.Value.ToString());
+                sentryEvent.Extra = props;
+
+                foreach (var tag in props)
+                {
+                    sentryEvent.Tags.Add(tag);
+                }
+            }
+            
+            return sentryEvent;
         }
     }
 }

--- a/NLog.Targets.Sentry/SentryTarget.cs
+++ b/NLog.Targets.Sentry/SentryTarget.cs
@@ -87,7 +87,7 @@ namespace NLog.Targets
 
                 // If the log event did not contain an exception and we're not ignoring
                 // those kinds of events then we'll send a "Message" to Sentry
-                if ( (logEvent.Exception != null && !IgnoreEventsWithNoException) || (logEvent.Exception != null))
+                if (logEvent.Exception != null || !IgnoreEventsWithNoException)
                 {
                     client.Value.Capture(LogEventToSentry(logEvent));
                 }

--- a/NLog.Targets.Sentry/app.config
+++ b/NLog.Targets.Sentry/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Per #7 I have added conversion of LogEventInfo to SentryEvent and fixed tests, even fixed some obsolete overloads for NLog.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bjarneriis/nlog.targets.sentry/8)

<!-- Reviewable:end -->
