### PR TITLE
Improve reliability of the target

### DIFF
--- a/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
+++ b/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
@@ -150,5 +150,20 @@ namespace NLog.Targets.Sentry.UnitTests
             Assert.IsTrue(lTags != null);
             Assert.IsTrue(lErrorLevel == ErrorLevel.Error);
         }
+
+        [TestCase("Trace", 0, ErrorLevel.Debug)]
+        [TestCase("Debug", 1, ErrorLevel.Debug)]
+        [TestCase("Info",  2, ErrorLevel.Info)]
+        [TestCase("Warn",  3, ErrorLevel.Warning)]
+        [TestCase("Error", 4, ErrorLevel.Error)]
+        [TestCase("Fatal", 5, ErrorLevel.Fatal)]
+        [TestCase("Off",   6, null)]
+        public void TestLevelMappings(string name, int ordinal, ErrorLevel? expectedErrorLevel)
+        {
+            var level = LogLevel.FromString(name);
+            Assert.AreEqual(level, LogLevel.FromOrdinal(ordinal));
+            var errorLevel = SentryTarget.TryGetErrorLevel(level);
+            Assert.AreEqual(expectedErrorLevel, errorLevel);
+        }
     }
 }

--- a/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
+++ b/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
@@ -40,7 +40,20 @@ namespace NLog.Targets.Sentry.UnitTests
         [Test]
         public void TestBadDsn()
         {
-            Assert.Throws<ArgumentException>(() => new SentryTarget(null) { Dsn = "http://localhost" });
+            var sentryTarget = new SentryTarget { Dsn = "http://localhost" };
+            var configuration = new LoggingConfiguration();
+            configuration.AddTarget("NLogSentry", sentryTarget);
+            configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Trace, sentryTarget));
+            LogManager.Configuration = configuration;
+            try
+            {
+                LogManager.GetCurrentClassLogger().Info("Test");
+                Assert.Fail("Expected exception not raised");
+            }
+            catch (NLogRuntimeException ex)
+            {
+                Assert.IsInstanceOf<ArgumentException>(ex.InnerException);
+            }
         }
 
         [Test]
@@ -62,7 +75,7 @@ namespace NLog.Targets.Sentry.UnitTests
                 .Returns("Done");
 
             // Setup NLog
-            var sentryTarget = new SentryTarget(sentryClient.Object)
+            var sentryTarget = new SentryTarget(() => sentryClient.Object)
             {
                 Dsn = "http://25e27038b1df4930b93c96c170d95527:d87ac60bb07b4be8908845b23e914dae@test/4",
             };
@@ -108,7 +121,7 @@ namespace NLog.Targets.Sentry.UnitTests
                 .Returns("Done");
 
             // Setup NLog
-            var sentryTarget = new SentryTarget(sentryClient.Object)
+            var sentryTarget = new SentryTarget(() => sentryClient.Object)
             {
                 Dsn = "http://25e27038b1df4930b93c96c170d95527:d87ac60bb07b4be8908845b23e914dae@test/4",
                 SendLogEventInfoPropertiesAsTags = true,


### PR DESCRIPTION
## Make conversion to string dictionary more robust

Avoid possible edge cases when converting from `Dictionary<object, object>` to `Dictionary<string, string>`.

All cases fairly unlikely, but wouldn't want to cause messages to be missed so best to be defensive here.

Possible issues:
1. Values of a dictionary can be null. Also filtering out blank string values.
2. Two distinct key objects can be converted to the same string representation. When this happens, concatenate all the matching values together as a workaround.
3. ToString could return null. Therefore, remove all properties will a null key or value string representation.
## Make the client thread-safe

The RavenClient is not marked as being thread-safe, but a single instance is used within the target. In addition, we mutate the Logger property to match the logger of the current event, meaning there could be a race condition between two threads changing the Logger and sending their message, causing messages to come from the wrong logger.

If this is a performance bottleneck, then perhaps a client could be created per logger (assuming that the rest of the client is thread-safe).
## Change where DSN parsing exceptions are thrown

Parsing the DSN can fail with exceptions, therefore, this is preferable to fail at the point of creating the client, rather than which trying to de-serialize the config.

A specific use case for this delayed failure is when using NLog with autoReload enabled, it will now only fail when trying to write messages, but can then still be re-configured as long as the lazy has
not been successfully initialized.
## Remove catching of all exceptions

NLog handles exceptions from targets internally, with it's default behaviour set to hide all exceptions and not rethrow them. Exceptions will only be propagated if the "throwExceptions" property is set to
true on the root "nlog" node.

Having a try-catch inside the target makes it more difficult to diagnose configuration issues.
