### PR TITLE
Add specific tag selection

### DIFF
--- a/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
+++ b/NLog.Targets.Sentry.UnitTests/NLog.Targets.Sentry.UnitTests.csproj
@@ -42,8 +42,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="SharpRaven">
-      <HintPath>..\packages\SharpRaven.1.4.3\lib\net45\SharpRaven.dll</HintPath>
+    <Reference Include="SharpRaven, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpRaven.2.1.0\lib\net45\SharpRaven.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
+++ b/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
@@ -150,5 +150,20 @@ namespace NLog.Targets.Sentry.UnitTests
             Assert.IsTrue(lTags != null);
             Assert.IsTrue(lErrorLevel == ErrorLevel.Error);
         }
+
+        [TestCase("Trace", 0, ErrorLevel.Debug)]
+        [TestCase("Debug", 1, ErrorLevel.Debug)]
+        [TestCase("Info",  2, ErrorLevel.Info)]
+        [TestCase("Warn",  3, ErrorLevel.Warning)]
+        [TestCase("Error", 4, ErrorLevel.Error)]
+        [TestCase("Fatal", 5, ErrorLevel.Fatal)]
+        [TestCase("Off",   6, null)]
+        public void TestLevelMappings(string name, int ordinal, ErrorLevel? expectedErrorLevel)
+        {
+            var level = LogLevel.FromString(name);
+            Assert.AreEqual(level, LogLevel.FromOrdinal(ordinal));
+            var errorLevel = SentryTarget.TryGetErrorLevel(level);
+            Assert.AreEqual(expectedErrorLevel, errorLevel);
+        }
     }
 }

--- a/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
+++ b/NLog.Targets.Sentry.UnitTests/SentryTargetTests.cs
@@ -40,7 +40,20 @@ namespace NLog.Targets.Sentry.UnitTests
         [Test]
         public void TestBadDsn()
         {
-            Assert.Throws<ArgumentException>(() => new SentryTarget(null) { Dsn = "http://localhost" });
+            var sentryTarget = new SentryTarget { Dsn = "http://localhost" };
+            var configuration = new LoggingConfiguration();
+            configuration.AddTarget("NLogSentry", sentryTarget);
+            configuration.LoggingRules.Add(new LoggingRule("*", LogLevel.Trace, sentryTarget));
+            LogManager.Configuration = configuration;
+            try
+            {
+                LogManager.GetCurrentClassLogger().Info("Test");
+                Assert.Fail("Expected exception not raised");
+            }
+            catch (NLogRuntimeException ex)
+            {
+                Assert.IsInstanceOf<ArgumentException>(ex.InnerException);
+            }
         }
 
         [Test]
@@ -62,7 +75,7 @@ namespace NLog.Targets.Sentry.UnitTests
                 .Returns("Done");
 
             // Setup NLog
-            var sentryTarget = new SentryTarget(sentryClient.Object)
+            var sentryTarget = new SentryTarget(() => sentryClient.Object)
             {
                 Dsn = "http://25e27038b1df4930b93c96c170d95527:d87ac60bb07b4be8908845b23e914dae@test/4",
             };
@@ -108,7 +121,7 @@ namespace NLog.Targets.Sentry.UnitTests
                 .Returns("Done");
 
             // Setup NLog
-            var sentryTarget = new SentryTarget(sentryClient.Object)
+            var sentryTarget = new SentryTarget(() => sentryClient.Object)
             {
                 Dsn = "http://25e27038b1df4930b93c96c170d95527:d87ac60bb07b4be8908845b23e914dae@test/4",
                 SendLogEventInfoPropertiesAsTags = true,

--- a/NLog.Targets.Sentry.UnitTests/packages.config
+++ b/NLog.Targets.Sentry.UnitTests/packages.config
@@ -4,5 +4,5 @@
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
   <package id="NLog" version="3.2.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SharpRaven" version="1.4.3" targetFramework="net45" />
+  <package id="SharpRaven" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
+++ b/NLog.Targets.Sentry/NLog.Targets.Sentry.csproj
@@ -36,8 +36,9 @@
     <Reference Include="NLog">
       <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="SharpRaven">
-      <HintPath>..\packages\SharpRaven.1.4.3\lib\net45\SharpRaven.dll</HintPath>
+    <Reference Include="SharpRaven, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpRaven.2.1.0\lib\net45\SharpRaven.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NLog.Targets.Sentry/Packages.config
+++ b/NLog.Targets.Sentry/Packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
   <package id="NLog" version="3.2.0.0" targetFramework="net45" />
-  <package id="SharpRaven" version="1.4.3" targetFramework="net45" />
+  <package id="SharpRaven" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/NLog.Targets.Sentry/SentryTarget.cs
+++ b/NLog.Targets.Sentry/SentryTarget.cs
@@ -10,7 +10,7 @@ namespace NLog.Targets
 // ReSharper restore CheckNamespace
 {
     [Target("Sentry")]
-    public class SentryTarget : TargetWithLayout
+    public class SentryTarget : Target
     {
         private readonly Func<IRavenClient> ravenClientFactory;
 
@@ -80,7 +80,7 @@ namespace NLog.Targets
             {
                 if (!IgnoreEventsWithNoException)
                 {
-                    var sentryMessage = new SentryMessage(Layout.Render(logEvent));
+                    var sentryMessage = new SentryMessage(logEvent.FormattedMessage);
                     client.CaptureMessage(sentryMessage, level.Value, extra: extras, tags: tags);
                 }
             }

--- a/NLog.Targets.Sentry/SentryTarget.cs
+++ b/NLog.Targets.Sentry/SentryTarget.cs
@@ -23,6 +23,7 @@ namespace NLog.Targets
         /// <summary>
         /// Determines whether events with no exceptions will be send to Sentry or not
         /// </summary>
+        [Obsolete("Use target filter conditions instead. See: https://github.com/NLog/NLog/wiki/Conditions")]
         public bool IgnoreEventsWithNoException { get; set; }
 
         /// <summary>
@@ -75,12 +76,15 @@ namespace NLog.Targets
             var client = CreateClient(logEvent);
             // If the log event did not contain an exception and we're not ignoring
             // those kinds of events then we'll send a "Message" to Sentry
-            if (logEvent.Exception == null && !IgnoreEventsWithNoException)
+            if (logEvent.Exception == null)
             {
-                var sentryMessage = new SentryMessage(Layout.Render(logEvent));
-                client.CaptureMessage(sentryMessage, level.Value, extra: extras, tags: tags);
+                if (!IgnoreEventsWithNoException)
+                {
+                    var sentryMessage = new SentryMessage(Layout.Render(logEvent));
+                    client.CaptureMessage(sentryMessage, level.Value, extra: extras, tags: tags);
+                }
             }
-            else if (logEvent.Exception != null)
+            else
             {
                 var sentryMessage = new SentryMessage(logEvent.FormattedMessage);
                 client.CaptureException(logEvent.Exception, extra: extras, level: level.Value, message: sentryMessage, tags: tags);


### PR DESCRIPTION
_This PR is dependent on #9 and contains the commits from that branch within it._

If SendLogEventInfoPropertiesAsTags is set to true, then all properties will still be used as tags. However, if set to false, then onlly the properties specified in the new TagProperties will be assigned as tags.
## Upgrade SharpRaven to 2.1.0

Due to the old API being deprecated, use the new API, which requires the sentry event to be constructed in a different way.
## Always use the log message as the sentry message

Treat all NLog messages the same and avoid differences in behaviour depending on if we have an exception.

Therefore the target has no need for a custom layout.
